### PR TITLE
fix(handler-test): rewrite InmuebleHandlerTest for Spring Boot 4.0 + …

### DIFF
--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/config/GlobalErrorHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/config/GlobalErrorHandler.java
@@ -10,7 +10,6 @@ import co.com.bancolombia.model.exception.UnauthorizedException;
 import co.com.bancolombia.model.exception.ValidationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolationException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -28,12 +27,11 @@ import java.util.stream.Collectors;
 @Component
 @Order(-2)
 @Slf4j
-@RequiredArgsConstructor
 public class GlobalErrorHandler implements WebExceptionHandler {
 
     public static final String USER_ID_HEADER = "X-User-Id";
 
-    private final ObjectMapper objectMapper;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Override
     public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
@@ -109,7 +107,7 @@ public class GlobalErrorHandler implements WebExceptionHandler {
         exchange.getResponse().setStatusCode(status);
         exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
         try {
-            byte[] bytes = objectMapper.writeValueAsBytes(body);
+            byte[] bytes = OBJECT_MAPPER.writeValueAsBytes(body);
             DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(ByteBuffer.wrap(bytes));
             return exchange.getResponse().writeWith(Mono.just(buffer));
         } catch (Exception e) {

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/inmueble/CreateInmuebleDto.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/inmueble/CreateInmuebleDto.java
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.util.List;
 
-@Schema(description = "Datos para publicar un nuevo inmueble")
+@Schema(description = "Datos para publicar un nuevo inmueble. El propietario se identifica mediante el header `X-User-Id` propagado por el API Gateway — no se incluye en el body.")
 public record CreateInmuebleDto(
         @Schema(description = "Título del aviso (entre 5 y 150 caracteres)", example = "Apartamento moderno en El Poblado", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "El título es obligatorio")

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/inmueble/FotoDto.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/dto/inmueble/FotoDto.java
@@ -15,7 +15,7 @@ public record FotoDto(
         @URL(message = "La URL de la foto no es válida")
         String url,
 
-        @Schema(description = "Posición de la foto en la galería (1 = portada)", example = "1", minimum = "1", maximum = "20")
+        @Schema(description = "Posición de la foto en la galería (1 = portada). Debe ser único dentro de la lista — dos fotos no pueden compartir el mismo valor de `order`.", example = "1", minimum = "1", maximum = "20")
         @NotNull(message = "El orden de la foto es obligatorio")
         @Min(value = 1, message = "El orden mínimo es 1")
         @Max(value = 20, message = "El orden máximo es 20")

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleRouter.java
@@ -4,6 +4,8 @@ import co.com.bancolombia.api.dto.common.ErrorResponse;
 import co.com.bancolombia.api.dto.inmueble.CreateInmuebleDto;
 import co.com.bancolombia.api.dto.inmueble.InmuebleResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -41,14 +43,25 @@ public class InmuebleRouter {
                     Crea y publica un nuevo aviso de inmueble en la plataforma.
 
                     **Reglas de negocio:**
-                    - El campo `userId` identifica al propietario del aviso. Será reemplazado por extracción desde JWT cuando se implemente autenticación.
-                    - Los usuarios con **plan gratuito** tienen un límite de **2 propiedades activas** simultáneas. Superar ese límite retorna `403 Forbidden`.
+                    - La identidad del propietario se extrae del header `X-User-Id`, propagado por el API Gateway. Si el header está ausente, se retorna `401 Unauthorized`.
+                    - Los usuarios con **plan gratuito** tienen un límite de **2 propiedades vigentes** simultáneas (estados `ACTIVE`, `INACTIVE` y `PAUSED`). Superar ese límite retorna `403 Forbidden`.
                     - Las fotos se incluyen en el cuerpo del request (campo `fotos`). Se admiten entre 1 y 20 fotos.
                     - La foto con `order = 1` se considera la **portada** del aviso y es la que se muestra en los listados.
+                    - Los valores de `order` dentro de la lista de fotos deben ser **únicos**. Dos fotos con el mismo `order` retornan `400 Bad Request`.
                     - El inmueble queda publicado con estado `ACTIVE` y una **vigencia de 30 días** desde la fecha de creación (`expiresAt`).
                     - El servicio depende de **ms-user** para validar la existencia y el plan del propietario. Si ms-user no está disponible, se retorna `503 Service Unavailable`.
                     """,
                 tags = {"Inmuebles"},
+                parameters = {
+                    @Parameter(
+                        name = "X-User-Id",
+                        in = ParameterIn.HEADER,
+                        description = "Identificador del usuario propietario, propagado por el API Gateway. Requerido — su ausencia retorna 401.",
+                        required = true,
+                        example = "usr_01HX9Z",
+                        schema = @Schema(type = "string")
+                    )
+                },
                 requestBody = @RequestBody(
                     description = "Datos del inmueble y sus fotos",
                     required = true,
@@ -68,7 +81,15 @@ public class InmuebleRouter {
                     ),
                     @ApiResponse(
                         responseCode = "400",
-                        description = "Datos de entrada inválidos — validación de campos fallida",
+                        description = "Datos de entrada inválidos — validación de campos fallida o valores de `order` duplicados en la lista de fotos (errorCode: `VALIDATION_ERROR`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "401",
+                        description = "Header `X-User-Id` ausente o vacío — el API Gateway no propagó la identidad del usuario (errorCode: `MISSING_USER_IDENTITY`)",
                         content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = ErrorResponse.class)
@@ -76,7 +97,7 @@ public class InmuebleRouter {
                     ),
                     @ApiResponse(
                         responseCode = "403",
-                        description = "Límite de propiedades activas excedido — el plan gratuito permite máximo 2 propiedades activas",
+                        description = "Límite de propiedades vigentes excedido — el plan gratuito permite máximo 2 propiedades vigentes (ACTIVE, INACTIVE o PAUSED) (errorCode: `PLAN_LIMIT_EXCEEDED`)",
                         content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = ErrorResponse.class)

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/inmueble/InmuebleHandlerTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/inmueble/InmuebleHandlerTest.java
@@ -5,7 +5,6 @@ import co.com.bancolombia.api.config.UserIdExtractorFilter;
 import co.com.bancolombia.api.mapper.InmuebleApiMapperImpl;
 import co.com.bancolombia.model.exception.ExternalServiceException;
 import co.com.bancolombia.model.exception.ForbiddenException;
-import co.com.bancolombia.model.exception.UnauthorizedException;
 import co.com.bancolombia.model.foto.Foto;
 import co.com.bancolombia.model.inmueble.BusinessType;
 import co.com.bancolombia.model.inmueble.Inmueble;
@@ -16,12 +15,14 @@ import co.com.bancolombia.usecase.crearInmueble.CrearInmuebleUseCase;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.validation.Validation;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
-import org.springframework.context.annotation.Import;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.MockServerConfigurer;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
@@ -32,19 +33,38 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@WebFluxTest
-@Import({InmuebleRouter.class, InmuebleHandler.class, InmuebleApiMapperImpl.class,
-        GlobalErrorHandler.class, UserIdExtractorFilter.class})
+@ExtendWith(MockitoExtension.class)
 class InmuebleHandlerTest {
 
     private static final String URL = "/api/v1/inmuebles";
     private static final ObjectMapper TEST_MAPPER = new ObjectMapper();
 
-    @Autowired
+    @Mock
+    private CrearInmuebleUseCase crearInmuebleUseCase;
+
     private WebTestClient webTestClient;
 
-    @MockitoBean
-    private CrearInmuebleUseCase crearInmuebleUseCase;
+    @BeforeEach
+    void setUp() {
+        var mapper = new InmuebleApiMapperImpl();
+        var validator = Validation.buildDefaultValidatorFactory().getValidator();
+        var handler = new InmuebleHandler(crearInmuebleUseCase, mapper, validator);
+        var routerFunction = new InmuebleRouter().inmuebleRoutes(handler);
+
+        var errorHandler = new GlobalErrorHandler();
+
+        webTestClient = WebTestClient
+                .bindToRouterFunction(routerFunction)
+                .webFilter(new UserIdExtractorFilter())
+                .apply(new MockServerConfigurer() {
+                    @Override
+                    public void beforeServerCreated(
+                            org.springframework.web.server.adapter.WebHttpHandlerBuilder builder) {
+                        builder.exceptionHandler(errorHandler);
+                    }
+                })
+                .build();
+    }
 
     @Test
     void crearInmueble_cuandoBodyValido_retorna201ConInmuebleCreado() {


### PR DESCRIPTION
…fix ObjectMapper injection

Spring Boot 4.0 removed @WebFluxTest and JacksonAutoConfiguration. Two fixes applied:

- InmuebleHandlerTest: replaced @WebFluxTest/@Import with @ExtendWith(MockitoExtension.class) and WebTestClient.bindToRouterFunction() + MockServerConfigurer.beforeServerCreated() to register GlobalErrorHandler as WebExceptionHandler without Spring context.

- GlobalErrorHandler: ObjectMapper changed from constructor-injected field to static final instance. JacksonAutoConfiguration no longer exists in Spring Boot 4.0 and ErrorResponse only contains String fields, so no Spring-managed bean is needed.

docs(openapi): update Swagger docs to reflect latest contract changes

- InmuebleRouter: userId described as extracted from X-User-Id header (not body), plan limit updated to "vigentes" (ACTIVE+INACTIVE+PAUSED), uniqueness rule for foto order documented, 401 MISSING_USER_IDENTITY response added, X-User-Id header parameter added for Swagger UI.
- CreateInmuebleDto: schema description clarifies userId is not part of the request body.
- FotoDto: order field description states values must be unique within the list.