### PR TITLE
feat(inmueble): implement PUT /api/v1/inmuebles/{id} endpoint (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ build-cache
 CLAUDE.md
 .claude/
 Task
+memory/

--- a/domain/model/src/main/java/co/com/bancolombia/model/events/UpdateInmuebleEvent.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/events/UpdateInmuebleEvent.java
@@ -1,0 +1,10 @@
+package co.com.bancolombia.model.events;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UpdateInmuebleEvent {
+    private final InmueblePublicData inmueble;
+}

--- a/domain/model/src/main/java/co/com/bancolombia/model/foto/gateways/FotoRepository.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/foto/gateways/FotoRepository.java
@@ -2,10 +2,12 @@ package co.com.bancolombia.model.foto.gateways;
 
 import co.com.bancolombia.model.foto.Foto;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
 public interface FotoRepository {
     Flux<Foto> saveAll(List<Foto> fotos);
     Flux<Foto> findByPropertyId(String propertyId);
+    Mono<Void> deleteAllByInmuebleId(String inmuebleId);
 }

--- a/domain/model/src/main/java/co/com/bancolombia/model/inmueble/Inmueble.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/inmueble/Inmueble.java
@@ -31,4 +31,27 @@ public class Inmueble {
     private LocalDateTime pausedAt;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public Inmueble update(Inmueble newInmueble) {
+        return Inmueble.builder()
+                .id(this.getId())
+                .userId(this.userId)
+                .title(newInmueble.getTitle())
+                .description(newInmueble.getDescription())
+                .squareMeters(newInmueble.getSquareMeters())
+                .price(newInmueble.getPrice())
+                .businessType(newInmueble.getBusinessType())
+                .propertyType(newInmueble.getPropertyType())
+                .status(this.status)
+                .department(newInmueble.getDepartment())
+                .country(newInmueble.getCountry())
+                .city(newInmueble.getCity())
+                .fullAddress(newInmueble.getFullAddress())
+                .publishedAt(this.publishedAt)
+                .expiresAt(this.expiresAt)
+                .pausedAt(this.pausedAt)
+                .createdAt(this.createdAt)
+                .updatedAt(this.updatedAt)
+                .build();
+    }
 }

--- a/domain/model/src/main/java/co/com/bancolombia/model/inmueble/gateways/InmuebleRepository.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/inmueble/gateways/InmuebleRepository.java
@@ -8,4 +8,5 @@ public interface InmuebleRepository {
     Mono<Inmueble> save(Inmueble inmueble);
     Mono<Long> countCurrentByUserId(String userId);
     Flux<Inmueble> findAllByUserId(String userId);
+    Mono<Inmueble> findById(String id);
 }

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/UpdateInmuebleUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/UpdateInmuebleUseCase.java
@@ -1,0 +1,55 @@
+package co.com.bancolombia.usecase.inmueble;
+
+import co.com.bancolombia.model.events.InmueblePublicData;
+import co.com.bancolombia.model.events.UpdateInmuebleEvent;
+import co.com.bancolombia.model.events.gateways.EventsGateway;
+import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.foto.Foto;
+import co.com.bancolombia.model.foto.gateways.FotoRepository;
+import co.com.bancolombia.model.inmueble.*;
+import co.com.bancolombia.model.inmueble.gateways.InmuebleRepository;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class UpdateInmuebleUseCase {
+
+    private final InmuebleRepository inmuebleRepository;
+    private final FotoRepository fotoRepository;
+    private  final EventsGateway eventsGateway;
+
+
+    public Mono<InmuebleConFotos> execute (Inmueble inmueble, List<Foto> photos) {
+        return inmuebleRepository.findById(inmueble.getId())
+                .switchIfEmpty(
+                        Mono.error(
+                                new NotFoundException(
+                                        "NOT_FOUND", "El inmueble no esta registrado: " + inmueble.getId()
+                                )
+                        )
+                ).map(inmuebleDb -> inmuebleDb.update(inmueble))
+                .flatMap(updated -> fotoRepository.deleteAllByInmuebleId(updated.getId())
+                        .then(inmuebleRepository.save(updated))
+                        .flatMap(saved -> fotoRepository.saveAll(photos)
+                                .collectList()
+                                .map(fotos -> new InmuebleConFotos(saved, fotos))
+                        )
+                )
+                .flatMap(this::emitEventAndReturn);
+
+    }
+
+    private Mono<InmuebleConFotos> emitEventAndReturn(InmuebleConFotos result) {
+        UpdateInmuebleEvent event = UpdateInmuebleEvent
+                .builder()
+                .inmueble(InmueblePublicData.from(result.inmueble(), result.photos()))
+                .build();
+
+        return eventsGateway.emit(event)
+                .thenReturn(result);
+    }
+
+
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/foto/FotoR2dbcRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/foto/FotoR2dbcRepository.java
@@ -2,8 +2,10 @@ package co.com.bancolombia.r2dbc.foto;
 
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface FotoR2dbcRepository extends ReactiveCrudRepository<FotoEntity, String> {
 
     Flux<FotoEntity> findByPropertyId(String propertyId);
+    Mono<Void> deleteAllByPropertyId(String propertyId);
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/foto/FotoRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/foto/FotoRepositoryAdapter.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.TransientDataAccessException;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
 import java.time.Duration;
@@ -34,6 +35,16 @@ public class FotoRepositoryAdapter implements FotoRepository {
                         .filter(ex -> ex instanceof TransientDataAccessException)
                         .doBeforeRetry(signal -> log.warn(
                                 "[FotoRepository] Reintento #{} en findByPropertyId() — causa: {}",
+                                signal.totalRetries() + 1, signal.failure().getMessage())));
+    }
+
+    @Override
+    public Mono<Void> deleteAllByInmuebleId(String inmuebleId) {
+        return r2dbcRepository.deleteAllByPropertyId(inmuebleId)
+                .retryWhen(Retry.fixedDelay(2, Duration.ofMillis(150))
+                        .filter(ex -> ex instanceof TransientDataAccessException)
+                        .doBeforeRetry(signal -> log.warn(
+                                "[FotoRepository] Reintento #{} en deleteAllByInmuebleId() — causa: {}",
                                 signal.totalRetries() + 1, signal.failure().getMessage())));
     }
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/inmueble/InmuebleRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/inmueble/InmuebleRepositoryAdapter.java
@@ -57,4 +57,17 @@ public class InmuebleRepositoryAdapter implements InmuebleRepository {
                 );
 
     }
+
+    @Override
+    public Mono<Inmueble> findById(String id) {
+        return r2dbcRepository.findById(id)
+                .map(mapper::toDomain)
+                .retryWhen(Retry.fixedDelay(2, Duration.ofMillis(150))
+                        .filter(ex -> ex instanceof TransientDataAccessException)
+                        .doBeforeRetry(signal -> log.warn(
+                                "[InmuebleRepository] Reintento #{} en findById() — causa: {}",
+                                signal.totalRetries() + 1, signal.failure().getMessage()
+                        ))
+                );
+    }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleHandler.java
@@ -7,6 +7,7 @@ import co.com.bancolombia.model.exception.UnauthorizedException;
 import co.com.bancolombia.model.exception.ValidationException;
 import co.com.bancolombia.usecase.inmueble.CrearInmuebleUseCase;
 import co.com.bancolombia.usecase.inmueble.FindAllImobilieByUserUseCase;
+import co.com.bancolombia.usecase.inmueble.UpdateInmuebleUseCase;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
@@ -29,6 +30,7 @@ public class InmuebleHandler {
 
     private final CrearInmuebleUseCase crearInmuebleUseCase;
     private final FindAllImobilieByUserUseCase findAllImobilieByUserUseCase;
+    private final UpdateInmuebleUseCase updateInmuebleUseCase;
 
     private final InmuebleApiMapper mapper;
     private final Validator validator;
@@ -71,6 +73,31 @@ public class InmuebleHandler {
                             .contentType(MediaType.APPLICATION_JSON)
                             .bodyValue(list)
                     );
+        });
+    }
+
+    public Mono<ServerResponse> updateInmueble(ServerRequest request) {
+        return Mono.deferContextual(ctx -> {
+            String userId = ctx.<String>getOrEmpty(UserIdExtractorFilter.CTX_USER_ID).orElse(null);
+            if (userId == null) {
+                return Mono.error(new UnauthorizedException("MISSING_USER_IDENTITY",
+                        "El gateway no proporcionó identidad de usuario"));
+            }
+
+            String inmuebleId = request.pathVariable("id");
+            log.info("[UPDATE_INMUEBLE] userId={} inmuebleId={} - iniciando actualización", userId, inmuebleId);
+            return request.bodyToMono(CreateInmuebleDto.class)
+                    .doOnNext(this::validate)
+                    .doOnNext(this::validateFotoOrders)
+                    .flatMap(dto -> updateInmuebleUseCase.execute(
+                            mapper.toInmueble(dto, userId).toBuilder().id(inmuebleId).build(),
+                            mapper.toFotos(dto.fotos())
+                    ))
+                    .doOnSuccess(result -> log.info("[UPDATE_INMUEBLE] userId={} inmuebleId={} - actualización exitosa", userId, inmuebleId))
+                    .flatMap(result -> ServerResponse
+                            .ok()
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .bodyValue(mapper.toResponse(result)));
         });
     }
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleRouter.java
@@ -175,12 +175,101 @@ public class InmuebleRouter {
                     )
                 }
             )
+        ),
+        @RouterOperation(
+            path = BASE_PATH + "/{id}",
+            method = RequestMethod.PUT,
+            beanClass = InmuebleHandler.class,
+            beanMethod = "updateInmueble",
+            operation = @Operation(
+                operationId = "updateInmueble",
+                summary = "Actualizar un inmueble existente",
+                description = """
+                    Actualiza los datos y las fotos de un inmueble publicado por el usuario autenticado.
+
+                    **Reglas de negocio:**
+                    - La identidad del propietario se extrae del header `X-User-Id`, propagado por el API Gateway. Si el header está ausente, se retorna `401 Unauthorized`.
+                    - Si el inmueble no existe, se retorna `404 Not Found`.
+                    - Las fotos anteriores son eliminadas y reemplazadas por las nuevas enviadas en el request.
+                    - Los valores de `order` dentro de la lista de fotos deben ser **únicos**. Dos fotos con el mismo `order` retornan `400 Bad Request`.
+                    """,
+                tags = {"Inmuebles"},
+                parameters = {
+                    @Parameter(
+                        name = "id",
+                        in = ParameterIn.PATH,
+                        description = "Identificador único del inmueble a actualizar",
+                        required = true,
+                        example = "550e8400-e29b-41d4-a716-446655440000",
+                        schema = @Schema(type = "string")
+                    ),
+                    @Parameter(
+                        name = "X-User-Id",
+                        in = ParameterIn.HEADER,
+                        description = "Identificador del usuario propietario, propagado por el API Gateway. Requerido — su ausencia retorna 401.",
+                        required = true,
+                        example = "usr_01HX9Z",
+                        schema = @Schema(type = "string")
+                    )
+                },
+                requestBody = @RequestBody(
+                    description = "Nuevos datos del inmueble y sus fotos",
+                    required = true,
+                    content = @Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = @Schema(implementation = CreateInmuebleDto.class)
+                    )
+                ),
+                responses = {
+                    @ApiResponse(
+                        responseCode = "200",
+                        description = "Inmueble actualizado exitosamente",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = InmuebleResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "400",
+                        description = "Datos de entrada inválidos — validación de campos fallida o valores de `order` duplicados en la lista de fotos (errorCode: `VALIDATION_ERROR`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "401",
+                        description = "Header `X-User-Id` ausente o vacío — el API Gateway no propagó la identidad del usuario (errorCode: `MISSING_USER_IDENTITY`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "404",
+                        description = "Inmueble no encontrado — el id proporcionado no corresponde a ningún inmueble registrado (errorCode: `NOT_FOUND`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "500",
+                        description = "Error interno del servidor",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    )
+                }
+            )
         )
     })
     @Bean
     public RouterFunction<ServerResponse> inmuebleRoutes(InmuebleHandler handler) {
         return RouterFunctions.route(
             POST(BASE_PATH).and(accept(MediaType.APPLICATION_JSON)),handler::crearInmueble)
-                .andRoute(GET(BASE_PATH).and(accept(MediaType.APPLICATION_JSON)), handler::getinmueblesByUser);
+                .andRoute(GET(BASE_PATH).and(accept(MediaType.APPLICATION_JSON)), handler::getinmueblesByUser)
+                .andRoute(PUT(BASE_PATH + "/{id}").and(accept(MediaType.APPLICATION_JSON)), handler::updateInmueble);
     }
 }


### PR DESCRIPTION
Add full update flow for existing properties across all layers.

Domain:
- Add Inmueble.update() method to apply field changes while preserving immutable fields (id, userId, status, timestamps)
- Add InmuebleRepository.findById() gateway contract
- Add FotoRepository.deleteAllByInmuebleId() gateway contract
- Add UpdateInmuebleEvent and UpdateInmuebleUseCase

Use case:
- Fetch property by id, throw NotFoundException if absent
- Apply field updates, replace all photos, persist and emit UpdateInmuebleEvent via EventsGateway

Adapters:
- Implement findById() and deleteAllByInmuebleId() in R2DBC adapters with Resilience4j fixedDelay retry on transient errors

Entry point:
- Add updateInmueble() handler method with userId extraction, path variable binding, validation and use case delegation
- Register PUT /{id} route in InmuebleRouter
- Add full OpenAPI @RouterOperation documentation for the endpoint

Closes: #5