### PR TITLE
feat(inmueble): implement publication lifecycle management — closes #6

### DIFF
--- a/domain/model/src/main/java/co/com/bancolombia/model/events/DeleteInmueble.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/events/DeleteInmueble.java
@@ -1,0 +1,17 @@
+package co.com.bancolombia.model.events;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeleteInmueble implements DomainEvent{
+    private static final String TYPE = "co.arriendo.facil.inmueble.updated";
+
+    private final String inmuebleId;
+
+    @Override
+    public String eventType() {
+        return TYPE;
+    }
+}

--- a/domain/model/src/main/java/co/com/bancolombia/model/events/DeleteInmuebleEvent.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/events/DeleteInmuebleEvent.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class DeleteInmueble implements DomainEvent{
-    private static final String TYPE = "co.arriendo.facil.inmueble.updated";
+public class DeleteInmuebleEvent implements DomainEvent{
+    private static final String TYPE = "co.arriendo.facil.inmueble.delete";
 
     private final String inmuebleId;
 

--- a/domain/model/src/main/java/co/com/bancolombia/model/events/DomainEvent.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/events/DomainEvent.java
@@ -1,0 +1,5 @@
+package co.com.bancolombia.model.events;
+
+public interface DomainEvent {
+    String eventType();
+}

--- a/domain/model/src/main/java/co/com/bancolombia/model/events/InmuebleCreatedEvent.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/events/InmuebleCreatedEvent.java
@@ -7,7 +7,15 @@ import java.util.Map;
 
 @Getter
 @Builder
-public class InmuebleCreatedEvent {
+public class InmuebleCreatedEvent implements DomainEvent {
+
+    public static final String EVENT_TYPE = "co.arriendo.facil.inmueble.created";
+
     private final Map<String, Object> user;
     private final InmueblePublicData inmueble;
+
+    @Override
+    public String eventType() {
+        return EVENT_TYPE;
+    }
 }

--- a/domain/model/src/main/java/co/com/bancolombia/model/events/UpdateInmuebleEvent.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/events/UpdateInmuebleEvent.java
@@ -5,6 +5,14 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class UpdateInmuebleEvent {
+public class UpdateInmuebleEvent implements DomainEvent {
+
+    public static final String EVENT_TYPE = "co.arriendo.facil.inmueble.updated";
+
     private final InmueblePublicData inmueble;
+
+    @Override
+    public String eventType() {
+        return EVENT_TYPE;
+    }
 }

--- a/domain/model/src/main/java/co/com/bancolombia/model/events/gateways/EventsGateway.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/events/gateways/EventsGateway.java
@@ -1,8 +1,9 @@
 package co.com.bancolombia.model.events.gateways;
 
+import co.com.bancolombia.model.events.DomainEvent;
 import reactor.core.publisher.Mono;
 
 public interface EventsGateway {
-    Mono<Void> emit(Object event);
-    Mono<Void> notify(Object event);
+    Mono<Void> emit(DomainEvent event);
+    Mono<Void> notify(DomainEvent event);
 }

--- a/domain/model/src/main/java/co/com/bancolombia/model/foto/Foto.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/foto/Foto.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
@@ -17,4 +19,13 @@ public class Foto {
     private String url;
     private Integer order;
     private LocalDateTime createdAt;
+
+    public static List<Foto> prepareForSave(List<Foto> fotos, String propertyId) {
+        return fotos.stream()
+                .map(foto -> foto.toBuilder()
+                        .id(UUID.randomUUID().toString())
+                        .propertyId(propertyId)
+                        .build())
+                .toList();
+    }
 }

--- a/domain/model/src/main/java/co/com/bancolombia/model/inmueble/Inmueble.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/inmueble/Inmueble.java
@@ -1,11 +1,14 @@
 package co.com.bancolombia.model.inmueble;
 
+import co.com.bancolombia.model.exception.ConflictException;
+import co.com.bancolombia.model.exception.ForbiddenException;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Getter
@@ -54,4 +57,57 @@ public class Inmueble {
                 .updatedAt(this.updatedAt)
                 .build();
     }
+
+    public Inmueble requireOwner(String requestingUserId) {
+        if (!this.userId.equals(requestingUserId)) {
+            throw new ForbiddenException("FORBIDDEN", "No tienes permiso para modificar este inmueble");
+        }
+        return this;
+    }
+
+    public Inmueble requireStatus(InmuebleStatus status) {
+        if (this.status != status) {
+            throw new ConflictException(
+                    "INVALID_STATE",
+                    String.format("El inmueble debe estar %s, estado actual: %s", status, this.status)
+            );
+        }
+        return this;
+    }
+
+    public Inmueble publish() {
+        LocalDateTime publishedAt = LocalDateTime.now();
+        return this.toBuilder()
+                .id(java.util.UUID.randomUUID().toString())
+                .status(InmuebleStatus.ACTIVE)
+                .publishedAt(publishedAt)
+                .expiresAt(publishedAt.plusDays(30))
+                .build();
+    }
+
+    public Inmueble pause() {
+        return this.toBuilder()
+                .status(InmuebleStatus.PAUSED)
+                .pausedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public Inmueble resume() {
+        Duration pauseDuration = Duration.between(this.pausedAt, LocalDateTime.now());
+        return this.toBuilder()
+                .status(InmuebleStatus.ACTIVE)
+                .expiresAt(this.expiresAt.plus(pauseDuration))
+                .pausedAt(null)
+                .build();
+    }
+
+    public Inmueble renew() {
+        return this.toBuilder()
+                .status(InmuebleStatus.ACTIVE)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
+    }
+
+
+
 }

--- a/domain/model/src/main/java/co/com/bancolombia/model/inmueble/Inmueble.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/inmueble/Inmueble.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
@@ -78,7 +79,7 @@ public class Inmueble {
     public Inmueble publish() {
         LocalDateTime publishedAt = LocalDateTime.now();
         return this.toBuilder()
-                .id(java.util.UUID.randomUUID().toString())
+                .id(UUID.randomUUID().toString())
                 .status(InmuebleStatus.ACTIVE)
                 .publishedAt(publishedAt)
                 .expiresAt(publishedAt.plusDays(30))

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/CrearInmuebleUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/CrearInmuebleUseCase.java
@@ -4,20 +4,18 @@ import co.com.bancolombia.model.events.InmuebleCreatedEvent;
 import co.com.bancolombia.model.events.InmueblePublicData;
 import co.com.bancolombia.model.events.gateways.EventsGateway;
 import co.com.bancolombia.model.exception.ForbiddenException;
+import co.com.bancolombia.model.exception.NotFoundException;
 import co.com.bancolombia.model.foto.Foto;
 import co.com.bancolombia.model.foto.gateways.FotoRepository;
 import co.com.bancolombia.model.inmueble.Inmueble;
 import co.com.bancolombia.model.inmueble.InmuebleConFotos;
-import co.com.bancolombia.model.inmueble.InmuebleStatus;
 import co.com.bancolombia.model.inmueble.gateways.InmuebleRepository;
 import co.com.bancolombia.model.user.gateways.UserClient;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 public class CrearInmuebleUseCase {
@@ -31,6 +29,7 @@ public class CrearInmuebleUseCase {
 
     public Mono<InmuebleConFotos> execute(Inmueble inmueble, List<Foto> photos) {
         return userClient.findById(inmueble.getUserId())
+                .switchIfEmpty(Mono.error(new NotFoundException("NOT_FOUND", "No se pudo obtener la informacion del usuario")))
                 .flatMap(userData -> checkPlanLimit(inmueble.getUserId())
                         .then(Mono.defer(() -> buildAndSaveInmueble(inmueble)))
                         .flatMap(saved -> savePhotos(photos, saved)
@@ -47,23 +46,11 @@ public class CrearInmuebleUseCase {
     }
 
     private Mono<Inmueble> buildAndSaveInmueble(Inmueble inmueble) {
-        LocalDateTime publishedAt = LocalDateTime.now();
-        return inmuebleRepository.save(inmueble.toBuilder()
-                .id(UUID.randomUUID().toString())
-                .status(InmuebleStatus.ACTIVE)
-                .publishedAt(publishedAt)
-                .expiresAt(publishedAt.plusDays(30))
-                .build());
+        return inmuebleRepository.save(inmueble.publish());
     }
 
     private Mono<List<Foto>> savePhotos(List<Foto> photos, Inmueble inmueble) {
-        List<Foto> photosWithId = photos.stream()
-                .map(photo -> photo.toBuilder()
-                        .id(UUID.randomUUID().toString())
-                        .propertyId(inmueble.getId())
-                        .build())
-                .toList();
-        return fotoRepository.saveAll(photosWithId).collectList();
+        return fotoRepository.saveAll(Foto.prepareForSave(photos, inmueble.getId())).collectList();
     }
 
     private Mono<InmuebleConFotos> emitEventAndReturn(Inmueble inmueble, List<Foto> photos, Map<String, Object> userData) {

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/PauseInmueblePublicationUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/PauseInmueblePublicationUseCase.java
@@ -1,6 +1,6 @@
 package co.com.bancolombia.usecase.inmueble;
 
-import co.com.bancolombia.model.events.DeleteInmueble;
+import co.com.bancolombia.model.events.DeleteInmuebleEvent;
 import co.com.bancolombia.model.events.gateways.EventsGateway;
 import co.com.bancolombia.model.exception.NotFoundException;
 import co.com.bancolombia.model.inmueble.Inmueble;
@@ -22,7 +22,7 @@ public class PauseInmueblePublicationUseCase {
                 .map(Inmueble::pause)
                 .flatMap(inmuebleRepository::save)
                 .flatMap(saved -> eventsGateway.emit(
-                        DeleteInmueble
+                        DeleteInmuebleEvent
                                 .builder()
                                 .inmuebleId(saved.getId())
                                 .build())

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/PauseInmueblePublicationUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/PauseInmueblePublicationUseCase.java
@@ -1,0 +1,32 @@
+package co.com.bancolombia.usecase.inmueble;
+
+import co.com.bancolombia.model.events.DeleteInmueble;
+import co.com.bancolombia.model.events.gateways.EventsGateway;
+import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.inmueble.Inmueble;
+import co.com.bancolombia.model.inmueble.InmuebleStatus;
+import co.com.bancolombia.model.inmueble.gateways.InmuebleRepository;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class PauseInmueblePublicationUseCase {
+    private final InmuebleRepository inmuebleRepository;
+    private  final EventsGateway eventsGateway;
+
+    public Mono<Void> execute(String inmuebleId, String userId) {
+        return inmuebleRepository.findById(inmuebleId)
+                .switchIfEmpty(Mono.error(new NotFoundException("NOT_FOUND", "No se encontro el inmueble")))
+                .map(inmueble -> inmueble.requireOwner(userId))
+                .map(inmueble -> inmueble.requireStatus(InmuebleStatus.ACTIVE))
+                .map(Inmueble::pause)
+                .flatMap(inmuebleRepository::save)
+                .flatMap(saved -> eventsGateway.emit(
+                        DeleteInmueble
+                                .builder()
+                                .inmuebleId(saved.getId())
+                                .build())
+                )
+                .then();
+    }
+}

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/RenewInmuebleUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/RenewInmuebleUseCase.java
@@ -1,0 +1,46 @@
+package co.com.bancolombia.usecase.inmueble;
+
+import co.com.bancolombia.model.events.InmuebleCreatedEvent;
+import co.com.bancolombia.model.events.InmueblePublicData;
+import co.com.bancolombia.model.events.gateways.EventsGateway;
+import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.foto.gateways.FotoRepository;
+import co.com.bancolombia.model.inmueble.Inmueble;
+import co.com.bancolombia.model.inmueble.InmuebleStatus;
+import co.com.bancolombia.model.inmueble.gateways.InmuebleRepository;
+import co.com.bancolombia.model.user.gateways.UserClient;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class RenewInmuebleUseCase {
+    private final InmuebleRepository inmuebleRepository;
+    private final UserClient userClient;
+    private final EventsGateway eventsGateway;
+    private final FotoRepository fotoRepository;
+
+    public Mono<Void> execute(String inmuebleId, String userId) {
+        return userClient.findById(userId)
+                .switchIfEmpty(
+                        Mono.error(new NotFoundException("NOT_FOUND", "No se pudo obtener la informacion del usuario"))
+                )
+                .flatMap(user -> inmuebleRepository.findById(inmuebleId)
+                        .switchIfEmpty(Mono.error(new NotFoundException("NOT_FOUND", "No hay informacion del inmueble")))
+                        .map(inmueble -> inmueble.requireOwner(userId))
+                        .map(inmueble -> inmueble.requireStatus(InmuebleStatus.INACTIVE))
+                        .map(Inmueble::renew)
+                        .flatMap(inmuebleRepository::save)
+                        .flatMap(saved -> fotoRepository.findByPropertyId(saved.getId()).collectList()
+                                .flatMap(fotos -> eventsGateway.emit(
+                                                InmuebleCreatedEvent.builder()
+                                                        .user(user)
+                                                        .inmueble(InmueblePublicData.from(saved, fotos))
+                                                        .build()
+                                        )
+                                )
+                        )
+                )
+                .then();
+
+    }
+}

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/ResumeInmuebleUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/ResumeInmuebleUseCase.java
@@ -1,0 +1,46 @@
+package co.com.bancolombia.usecase.inmueble;
+
+import co.com.bancolombia.model.events.InmuebleCreatedEvent;
+import co.com.bancolombia.model.events.InmueblePublicData;
+import co.com.bancolombia.model.events.gateways.EventsGateway;
+import co.com.bancolombia.model.exception.NotFoundException;
+import co.com.bancolombia.model.foto.gateways.FotoRepository;
+import co.com.bancolombia.model.inmueble.Inmueble;
+import co.com.bancolombia.model.inmueble.InmuebleStatus;
+import co.com.bancolombia.model.inmueble.gateways.InmuebleRepository;
+import co.com.bancolombia.model.user.gateways.UserClient;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class ResumeInmuebleUseCase {
+    private final InmuebleRepository inmuebleRepository;
+    private final UserClient userClient;
+    private final EventsGateway eventsGateway;
+    private final FotoRepository fotoRepository;
+
+    public Mono<Void> execute(String inmuebleId, String userId) {
+        return userClient.findById(userId)
+                .switchIfEmpty(
+                        Mono.error(new NotFoundException("NOT_FOUND", "No se pudo obtener la informacion del usuario"))
+                )
+                .flatMap(user -> inmuebleRepository.findById(inmuebleId)
+                        .switchIfEmpty(Mono.error(new NotFoundException("NOT_FOUND", "No hay informacion del inmueble")))
+                        .map(inmueble -> inmueble.requireOwner(userId))
+                        .map(inmueble -> inmueble.requireStatus(InmuebleStatus.PAUSED))
+                        .map(Inmueble::resume)
+                        .flatMap(inmuebleRepository::save)
+                        .flatMap(saved -> fotoRepository.findByPropertyId(saved.getId()).collectList()
+                                .flatMap(fotos -> eventsGateway.emit(
+                                                InmuebleCreatedEvent.builder()
+                                                        .user(user)
+                                                        .inmueble(InmueblePublicData.from(saved, fotos))
+                                                        .build()
+                                        )
+                                )
+                        )
+                )
+                .then();
+
+    }
+}

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/UpdateInmuebleUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/UpdateInmuebleUseCase.java
@@ -3,6 +3,7 @@ package co.com.bancolombia.usecase.inmueble;
 import co.com.bancolombia.model.events.InmueblePublicData;
 import co.com.bancolombia.model.events.UpdateInmuebleEvent;
 import co.com.bancolombia.model.events.gateways.EventsGateway;
+import co.com.bancolombia.model.exception.ForbiddenException;
 import co.com.bancolombia.model.exception.NotFoundException;
 import co.com.bancolombia.model.foto.Foto;
 import co.com.bancolombia.model.foto.gateways.FotoRepository;
@@ -29,7 +30,9 @@ public class UpdateInmuebleUseCase {
                                         "NOT_FOUND", "El inmueble no esta registrado: " + inmueble.getId()
                                 )
                         )
-                ).map(inmuebleDb -> inmuebleDb.update(inmueble))
+                )
+                .map(inmuebleDb -> inmuebleDb.requireOwner(inmueble.getUserId()))
+                .map(inmuebleDb -> inmuebleDb.update(inmueble))
                 .flatMap(updated -> fotoRepository.deleteAllByInmuebleId(updated.getId())
                         .then(inmuebleRepository.save(updated))
                         .flatMap(saved -> fotoRepository.saveAll(photos)

--- a/infrastructure/driven-adapters/async-event-bus/src/main/java/co/com/bancolombia/events/ReactiveEventsGateway.java
+++ b/infrastructure/driven-adapters/async-event-bus/src/main/java/co/com/bancolombia/events/ReactiveEventsGateway.java
@@ -1,5 +1,6 @@
 package co.com.bancolombia.events;
 
+import co.com.bancolombia.model.events.DomainEvent;
 import co.com.bancolombia.model.events.gateways.EventsGateway;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.builder.CloudEventBuilder;
@@ -23,19 +24,18 @@ import static reactor.core.publisher.Mono.from;
 @EnableDomainEventBus
 public class ReactiveEventsGateway implements EventsGateway {
 
-    public static final String INMUEBLE_CREATED_EVENT = "co.arriendo-facil.inmueble.created";
     public static final String EVENT_SOURCE = "ms-immobilie";
 
     private final DomainEventBus domainEventBus;
     private final JsonMapper mapper;
 
     @Override
-    public Mono<Void> emit(Object event) {
-        log.log(Level.INFO, "Publicando evento: {0}", INMUEBLE_CREATED_EVENT);
+    public Mono<Void> emit(DomainEvent event) {
+        log.log(Level.INFO, "Publicando evento: {0}", event.eventType());
         CloudEvent cloudEvent = CloudEventBuilder.v1()
                 .withId(UUID.randomUUID().toString())
                 .withSource(URI.create(EVENT_SOURCE))
-                .withType(INMUEBLE_CREATED_EVENT)
+                .withType(event.eventType())
                 .withTime(OffsetDateTime.now())
                 .withData("application/json", JsonCloudEventData.wrap(mapper.valueToTree(event)))
                 .build();
@@ -43,12 +43,12 @@ public class ReactiveEventsGateway implements EventsGateway {
     }
 
     @Override
-    public Mono<Void> notify(Object event) {
-        log.log(Level.INFO, "Publicando notificacion: {0}", INMUEBLE_CREATED_EVENT);
+    public Mono<Void> notify(DomainEvent event) {
+        log.log(Level.INFO, "Publicando notificacion: {0}", event.eventType());
         CloudEvent cloudEvent = CloudEventBuilder.v1()
                 .withId(UUID.randomUUID().toString())
                 .withSource(URI.create(EVENT_SOURCE))
-                .withType(INMUEBLE_CREATED_EVENT)
+                .withType(event.eventType())
                 .withTime(OffsetDateTime.now())
                 .withData("application/json", JsonCloudEventData.wrap(mapper.valueToTree(event)))
                 .build();

--- a/infrastructure/driven-adapters/async-event-bus/src/test/java/co/com/bancolombia/events/ReactiveEventsGatewayTest.java
+++ b/infrastructure/driven-adapters/async-event-bus/src/test/java/co/com/bancolombia/events/ReactiveEventsGatewayTest.java
@@ -1,5 +1,6 @@
 package co.com.bancolombia.events;
 
+import co.com.bancolombia.model.events.DomainEvent;
 import io.cloudevents.CloudEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,8 @@ class ReactiveEventsGatewayTest {
 
     private ReactiveEventsGateway gateway;
 
-    private static final Object DUMMY_EVENT = new Object();
+    private static final String TEST_EVENT_TYPE = "co.arriendo-facil.test.event";
+    private static final DomainEvent DUMMY_EVENT = () -> TEST_EVENT_TYPE;
 
     @BeforeEach
     void setUp() {
@@ -61,8 +63,7 @@ class ReactiveEventsGatewayTest {
         gateway.emit(DUMMY_EVENT).block();
 
         verify(domainEventBus).emit(captor.capture());
-        assertThat(captor.getValue().getType())
-                .isEqualTo(ReactiveEventsGateway.INMUEBLE_CREATED_EVENT);
+        assertThat(captor.getValue().getType()).isEqualTo(TEST_EVENT_TYPE);
     }
 
     @Test
@@ -141,8 +142,7 @@ class ReactiveEventsGatewayTest {
         gateway.notify(DUMMY_EVENT).block();
 
         verify(domainEventBus).emit(captor.capture());
-        assertThat(captor.getValue().getType())
-                .isEqualTo(ReactiveEventsGateway.INMUEBLE_CREATED_EVENT);
+        assertThat(captor.getValue().getType()).isEqualTo(TEST_EVENT_TYPE);
     }
 
     @Test

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleHandler.java
@@ -5,9 +5,7 @@ import co.com.bancolombia.api.dto.inmueble.CreateInmuebleDto;
 import co.com.bancolombia.api.mapper.InmuebleApiMapper;
 import co.com.bancolombia.model.exception.UnauthorizedException;
 import co.com.bancolombia.model.exception.ValidationException;
-import co.com.bancolombia.usecase.inmueble.CrearInmuebleUseCase;
-import co.com.bancolombia.usecase.inmueble.FindAllImobilieByUserUseCase;
-import co.com.bancolombia.usecase.inmueble.UpdateInmuebleUseCase;
+import co.com.bancolombia.usecase.inmueble.*;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
@@ -18,7 +16,6 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Set;
@@ -31,74 +28,109 @@ public class InmuebleHandler {
     private final CrearInmuebleUseCase crearInmuebleUseCase;
     private final FindAllImobilieByUserUseCase findAllImobilieByUserUseCase;
     private final UpdateInmuebleUseCase updateInmuebleUseCase;
+    private final PauseInmueblePublicationUseCase pauseInmueblePublicationUseCase;
+    private final ResumeInmuebleUseCase resumeInmuebleUseCase;
+    private final RenewInmuebleUseCase renewInmuebleUseCase;
 
     private final InmuebleApiMapper mapper;
     private final Validator validator;
 
     public Mono<ServerResponse> crearInmueble(ServerRequest request) {
-        return Mono.deferContextual(ctx -> {
-            String userId = ctx.<String>getOrEmpty(UserIdExtractorFilter.CTX_USER_ID).orElse(null);
-            if (userId == null) {
-                return Mono.error(new UnauthorizedException("MISSING_USER_IDENTITY",
-                        "El gateway no proporcionó identidad de usuario"));
-            }
-            log.info("[CREATE_INMUEBLE] userId={} - iniciando creación de inmueble", userId);
-            return request.bodyToMono(CreateInmuebleDto.class)
-                    .doOnNext(this::validate)
-                    .doOnNext(this::validateFotoOrders)
-                    .flatMap(dto -> crearInmuebleUseCase.execute(mapper.toInmueble(dto, userId), mapper.toFotos(dto.fotos())))
-                    .doOnSuccess(result -> log.info("[CREATE_INMUEBLE] userId={} - inmueble creado id={}", userId, result.inmueble().getId()))
-                    .flatMap(result -> ServerResponse
-                            .status(HttpStatus.CREATED)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .bodyValue(mapper.toResponse(result)));
-        });
+        return extractUserId(request)
+                .flatMap(userId -> {
+                    log.info("[CREATE_INMUEBLE] userId={} - iniciando creación de inmueble", userId);
+                    return request.bodyToMono(CreateInmuebleDto.class)
+                            .doOnNext(this::validate)
+                            .doOnNext(this::validateFotoOrders)
+                            .flatMap(dto -> crearInmuebleUseCase
+                                    .execute(mapper.toInmueble(dto, userId), mapper.toFotos(dto.fotos())))
+                            .doOnSuccess(result -> log.info(
+                                    "[CREATE_INMUEBLE] userId={} - inmueble creado id={}",
+                                    userId,
+                                    result.inmueble().getId()))
+                            .flatMap(result -> ServerResponse
+                                    .status(HttpStatus.CREATED)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .bodyValue(mapper.toResponse(result)));
+                });
     }
 
     public Mono<ServerResponse> getinmueblesByUser(ServerRequest request) {
-        return Mono.deferContextual(ctx -> {
-            String userId = ctx.<String>getOrEmpty(UserIdExtractorFilter.CTX_USER_ID).orElse(null);
-
-            if (userId == null) {
-                return Mono.error(new ValidationException("MISSING_USER_IDENTITY", "No hay usuario para consultar"));
-            }
-
-            log.info("[GET_INMUEBLE_BY_USER] userId={} - iniciando consulta de propiedades", userId);
-
-            return findAllImobilieByUserUseCase.execute(userId)
-                    .map(mapper::toResponse)
-                    .collectList()
-                    .flatMap(list -> ServerResponse
-                            .ok()
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .bodyValue(list)
-                    );
-        });
+        return extractUserId(request)
+                .flatMap(userId -> {
+                    log.info("[GET_INMUEBLE_BY_USER] userId={} - iniciando consulta de propiedades", userId);
+                    return findAllImobilieByUserUseCase.execute(userId)
+                            .map(mapper::toResponse)
+                            .collectList()
+                            .flatMap(list -> ServerResponse
+                                    .ok()
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .bodyValue(list));
+                });
     }
 
     public Mono<ServerResponse> updateInmueble(ServerRequest request) {
-        return Mono.deferContextual(ctx -> {
-            String userId = ctx.<String>getOrEmpty(UserIdExtractorFilter.CTX_USER_ID).orElse(null);
-            if (userId == null) {
-                return Mono.error(new UnauthorizedException("MISSING_USER_IDENTITY",
-                        "El gateway no proporcionó identidad de usuario"));
-            }
+        return extractUserId(request)
+                .flatMap(userId -> {
+                    String inmuebleId = request.pathVariable("id");
+                    log.info("[UPDATE_INMUEBLE] userId={} inmuebleId={} - iniciando actualización", userId, inmuebleId);
+                    return request.bodyToMono(CreateInmuebleDto.class)
+                            .doOnNext(this::validate)
+                            .doOnNext(this::validateFotoOrders)
+                            .flatMap(dto -> updateInmuebleUseCase.execute(
+                                    mapper.toInmueble(dto, userId).toBuilder().id(inmuebleId).build(),
+                                    mapper.toFotos(dto.fotos())
+                            ))
+                            .doOnSuccess(result -> log.info(
+                                    "[UPDATE_INMUEBLE] userId={} inmuebleId={} - actualización exitosa",
+                                    userId,
+                                    inmuebleId))
+                            .flatMap(result -> ServerResponse
+                                    .ok()
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .bodyValue(mapper.toResponse(result)));
+                });
+    }
 
-            String inmuebleId = request.pathVariable("id");
-            log.info("[UPDATE_INMUEBLE] userId={} inmuebleId={} - iniciando actualización", userId, inmuebleId);
-            return request.bodyToMono(CreateInmuebleDto.class)
-                    .doOnNext(this::validate)
-                    .doOnNext(this::validateFotoOrders)
-                    .flatMap(dto -> updateInmuebleUseCase.execute(
-                            mapper.toInmueble(dto, userId).toBuilder().id(inmuebleId).build(),
-                            mapper.toFotos(dto.fotos())
-                    ))
-                    .doOnSuccess(result -> log.info("[UPDATE_INMUEBLE] userId={} inmuebleId={} - actualización exitosa", userId, inmuebleId))
-                    .flatMap(result -> ServerResponse
-                            .ok()
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .bodyValue(mapper.toResponse(result)));
-        });
+    public Mono<ServerResponse> pauseInmueble(ServerRequest request) {
+        return extractUserId(request)
+                .flatMap(userId -> {
+                    String inmuebleId = request.pathVariable("id");
+                    log.info("[PAUSE_INMUEBLE] userId={} inmuebleId={} - iniciando pausa", userId, inmuebleId);
+                    return pauseInmueblePublicationUseCase.execute(inmuebleId, userId)
+                            .then(ServerResponse.noContent().build());
+                });
+    }
+
+    public Mono<ServerResponse> resumeInmueble(ServerRequest request) {
+        return extractUserId(request)
+                .flatMap(userId -> {
+                    String inmuebleId = request.pathVariable("id");
+                    log.info("[RESUME_INMUEBLE] userId={} inmuebleId={} - iniciando reactivacion", userId, inmuebleId);
+                    return resumeInmuebleUseCase.execute(inmuebleId, userId)
+                            .then(ServerResponse.noContent().build());
+                });
+    }
+
+    public Mono<ServerResponse> renewInmueble(ServerRequest request) {
+        return extractUserId(request)
+                .flatMap(userId -> {
+                    String inmuebleId = request.pathVariable("id");
+                    log.info("[RENEW_INMUEBLE] userId={} inmuebleId={} - iniciando renovacion", userId, inmuebleId);
+                    return renewInmuebleUseCase.execute(inmuebleId, userId)
+                            .then(ServerResponse.noContent().build());
+                });
+    }
+
+    private Mono<String> extractUserId(ServerRequest request) {
+        return Mono.deferContextual(ctx ->
+                ctx.<String>getOrEmpty(UserIdExtractorFilter.CTX_USER_ID)
+                        .map(Mono::just)
+                        .orElseGet(() -> Mono.error(new UnauthorizedException(
+                                "MISSING_USER_IDENTITY",
+                                "El gateway no proporcionó identidad de usuario"
+                        )))
+        );
     }
 
     private void validate(Object body) {

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleRouter.java
@@ -177,6 +177,278 @@ public class InmuebleRouter {
             )
         ),
         @RouterOperation(
+            path = BASE_PATH + "/{id}/pause",
+            method = RequestMethod.PATCH,
+            beanClass = InmuebleHandler.class,
+            beanMethod = "pauseInmueble",
+            operation = @Operation(
+                operationId = "pauseInmueble",
+                summary = "Pausar la publicación de un inmueble",
+                description = """
+                    Pausa la publicación de un inmueble activo. El inmueble deja de aparecer en los resultados de búsqueda.
+
+                    **Reglas de negocio:**
+                    - La identidad del propietario se extrae del header `X-User-Id`, propagado por el API Gateway. Si el header está ausente, se retorna `401 Unauthorized`.
+                    - Solo el propietario del inmueble puede pausarlo. Intentar pausar un inmueble ajeno retorna `403 Forbidden`.
+                    - El inmueble debe estar en estado `ACTIVE` para poder pausarse. Cualquier otro estado retorna `409 Conflict`.
+                    - Si el inmueble no existe, se retorna `404 Not Found`.
+                    """,
+                tags = {"Inmuebles"},
+                parameters = {
+                    @Parameter(
+                        name = "id",
+                        in = ParameterIn.PATH,
+                        description = "Identificador único del inmueble a pausar",
+                        required = true,
+                        example = "550e8400-e29b-41d4-a716-446655440000",
+                        schema = @Schema(type = "string")
+                    ),
+                    @Parameter(
+                        name = "X-User-Id",
+                        in = ParameterIn.HEADER,
+                        description = "Identificador del usuario propietario, propagado por el API Gateway. Requerido — su ausencia retorna 401.",
+                        required = true,
+                        example = "usr_01HX9Z",
+                        schema = @Schema(type = "string")
+                    )
+                },
+                responses = {
+                    @ApiResponse(
+                        responseCode = "204",
+                        description = "Inmueble pausado exitosamente"
+                    ),
+                    @ApiResponse(
+                        responseCode = "401",
+                        description = "Header `X-User-Id` ausente o vacío — el API Gateway no propagó la identidad del usuario (errorCode: `MISSING_USER_IDENTITY`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "403",
+                        description = "El usuario no es propietario del inmueble (errorCode: `FORBIDDEN`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "404",
+                        description = "Inmueble no encontrado (errorCode: `NOT_FOUND`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "409",
+                        description = "El inmueble no está en estado ACTIVE — transición de estado inválida (errorCode: `INVALID_STATE`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "500",
+                        description = "Error interno del servidor",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    )
+                }
+            )
+        ),
+        @RouterOperation(
+            path = BASE_PATH + "/{id}/resume",
+            method = RequestMethod.PATCH,
+            beanClass = InmuebleHandler.class,
+            beanMethod = "resumeInmueble",
+            operation = @Operation(
+                operationId = "resumeInmueble",
+                summary = "Reactivar la publicación de un inmueble",
+                description = """
+                    Reactiva un inmueble pausado. El inmueble vuelve a aparecer en los resultados de búsqueda.
+
+                    **Reglas de negocio:**
+                    - La identidad del propietario se extrae del header `X-User-Id`, propagado por el API Gateway. Si el header está ausente, se retorna `401 Unauthorized`.
+                    - Solo el propietario del inmueble puede reactivarlo. Intentar reactivar un inmueble ajeno retorna `403 Forbidden`.
+                    - El inmueble debe estar en estado `PAUSED` para poder reactivarse. Cualquier otro estado retorna `409 Conflict`.
+                    - Si el inmueble no existe, se retorna `404 Not Found`.
+                    - El tiempo que el inmueble estuvo pausado **no descuenta** de su vigencia: `expiresAt` se extiende automáticamente por la duración de la pausa.
+                    - El servicio depende de **ms-user** para validar la existencia del propietario. Si ms-user no está disponible, se retorna `503 Service Unavailable`.
+                    """,
+                tags = {"Inmuebles"},
+                parameters = {
+                    @Parameter(
+                        name = "id",
+                        in = ParameterIn.PATH,
+                        description = "Identificador único del inmueble a reactivar",
+                        required = true,
+                        example = "550e8400-e29b-41d4-a716-446655440000",
+                        schema = @Schema(type = "string")
+                    ),
+                    @Parameter(
+                        name = "X-User-Id",
+                        in = ParameterIn.HEADER,
+                        description = "Identificador del usuario propietario, propagado por el API Gateway. Requerido — su ausencia retorna 401.",
+                        required = true,
+                        example = "usr_01HX9Z",
+                        schema = @Schema(type = "string")
+                    )
+                },
+                responses = {
+                    @ApiResponse(
+                        responseCode = "204",
+                        description = "Inmueble reactivado exitosamente"
+                    ),
+                    @ApiResponse(
+                        responseCode = "401",
+                        description = "Header `X-User-Id` ausente o vacío — el API Gateway no propagó la identidad del usuario (errorCode: `MISSING_USER_IDENTITY`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "403",
+                        description = "El usuario no es propietario del inmueble (errorCode: `FORBIDDEN`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "404",
+                        description = "Inmueble no encontrado (errorCode: `NOT_FOUND`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "409",
+                        description = "El inmueble no está en estado PAUSED — transición de estado inválida (errorCode: `INVALID_STATE`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "503",
+                        description = "Servicio ms-user no disponible — no fue posible validar el propietario",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "500",
+                        description = "Error interno del servidor",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    )
+                }
+            )
+        ),
+        @RouterOperation(
+            path = BASE_PATH + "/{id}/renew",
+            method = RequestMethod.PATCH,
+            beanClass = InmuebleHandler.class,
+            beanMethod = "renewInmueble",
+            operation = @Operation(
+                operationId = "renewInmueble",
+                summary = "Renovar la publicación de un inmueble",
+                description = """
+                    Renueva la vigencia de un inmueble expirado. El inmueble vuelve a aparecer en los resultados de búsqueda con una vigencia de 30 días a partir del momento de la renovación.
+
+                    **Reglas de negocio:**
+                    - La identidad del propietario se extrae del header `X-User-Id`, propagado por el API Gateway. Si el header está ausente, se retorna `401 Unauthorized`.
+                    - Solo el propietario del inmueble puede renovarlo. Intentar renovar un inmueble ajeno retorna `403 Forbidden`.
+                    - El inmueble debe estar en estado `INACTIVE` para poder renovarse. Cualquier otro estado retorna `409 Conflict`.
+                    - Si el inmueble no existe, se retorna `404 Not Found`.
+                    - La fecha original de publicación (`publishedAt`) no se modifica; solo se actualiza `expiresAt` con 30 días desde el momento de la renovación.
+                    - El servicio depende de **ms-user** para validar la existencia del propietario. Si ms-user no está disponible, se retorna `503 Service Unavailable`.
+                    """,
+                tags = {"Inmuebles"},
+                parameters = {
+                    @Parameter(
+                        name = "id",
+                        in = ParameterIn.PATH,
+                        description = "Identificador único del inmueble a renovar",
+                        required = true,
+                        example = "550e8400-e29b-41d4-a716-446655440000",
+                        schema = @Schema(type = "string")
+                    ),
+                    @Parameter(
+                        name = "X-User-Id",
+                        in = ParameterIn.HEADER,
+                        description = "Identificador del usuario propietario, propagado por el API Gateway. Requerido — su ausencia retorna 401.",
+                        required = true,
+                        example = "usr_01HX9Z",
+                        schema = @Schema(type = "string")
+                    )
+                },
+                responses = {
+                    @ApiResponse(
+                        responseCode = "204",
+                        description = "Inmueble renovado exitosamente"
+                    ),
+                    @ApiResponse(
+                        responseCode = "401",
+                        description = "Header `X-User-Id` ausente o vacío — el API Gateway no propagó la identidad del usuario (errorCode: `MISSING_USER_IDENTITY`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "403",
+                        description = "El usuario no es propietario del inmueble (errorCode: `FORBIDDEN`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "404",
+                        description = "Inmueble no encontrado (errorCode: `NOT_FOUND`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "409",
+                        description = "El inmueble no está en estado INACTIVE — transición de estado inválida (errorCode: `INVALID_STATE`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "503",
+                        description = "Servicio ms-user no disponible — no fue posible validar el propietario",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "500",
+                        description = "Error interno del servidor",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    )
+                }
+            )
+        ),
+        @RouterOperation(
             path = BASE_PATH + "/{id}",
             method = RequestMethod.PUT,
             beanClass = InmuebleHandler.class,
@@ -270,6 +542,9 @@ public class InmuebleRouter {
         return RouterFunctions.route(
             POST(BASE_PATH).and(accept(MediaType.APPLICATION_JSON)),handler::crearInmueble)
                 .andRoute(GET(BASE_PATH).and(accept(MediaType.APPLICATION_JSON)), handler::getinmueblesByUser)
-                .andRoute(PUT(BASE_PATH + "/{id}").and(accept(MediaType.APPLICATION_JSON)), handler::updateInmueble);
+                .andRoute(PUT(BASE_PATH + "/{id}").and(accept(MediaType.APPLICATION_JSON)), handler::updateInmueble)
+                .andRoute(PATCH(BASE_PATH + "/{id}/pause").and(accept(MediaType.APPLICATION_JSON)), handler::pauseInmueble)
+                .andRoute(PATCH(BASE_PATH + "/{id}/resume").and(accept(MediaType.APPLICATION_JSON)), handler::resumeInmueble)
+                .andRoute(PATCH(BASE_PATH + "/{id}/renew").and(accept(MediaType.APPLICATION_JSON)), handler::renewInmueble);
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/inmueble/InmuebleHandlerTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/inmueble/InmuebleHandlerTest.java
@@ -16,6 +16,8 @@ import co.com.bancolombia.model.exception.NotFoundException;
 import co.com.bancolombia.usecase.inmueble.CrearInmuebleUseCase;
 import co.com.bancolombia.usecase.inmueble.FindAllImobilieByUserUseCase;
 import co.com.bancolombia.usecase.inmueble.PauseInmueblePublicationUseCase;
+import co.com.bancolombia.usecase.inmueble.RenewInmuebleUseCase;
+import co.com.bancolombia.usecase.inmueble.ResumeInmuebleUseCase;
 import co.com.bancolombia.usecase.inmueble.UpdateInmuebleUseCase;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -57,13 +59,19 @@ class InmuebleHandlerTest {
     @Mock
     private PauseInmueblePublicationUseCase pauseInmueblePublicationUseCase;
 
+    @Mock
+    private ResumeInmuebleUseCase resumeInmuebleUseCase;
+
+    @Mock
+    private RenewInmuebleUseCase renewInmuebleUseCase;
+
     private WebTestClient webTestClient;
 
     @BeforeEach
     void setUp() {
         var mapper = new InmuebleApiMapperImpl();
         var validator = Validation.buildDefaultValidatorFactory().getValidator();
-        var handler = new InmuebleHandler(crearInmuebleUseCase, findAllImobilieByUserUseCase, updateInmuebleUseCase, pauseInmueblePublicationUseCase, mapper, validator);
+        var handler = new InmuebleHandler(crearInmuebleUseCase, findAllImobilieByUserUseCase, updateInmuebleUseCase, pauseInmueblePublicationUseCase, resumeInmuebleUseCase, renewInmuebleUseCase, mapper, validator);
         var routerFunction = new InmuebleRouter().inmuebleRoutes(handler);
 
         var errorHandler = new GlobalErrorHandler();

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/inmueble/InmuebleHandlerTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/bancolombia/api/inmueble/InmuebleHandlerTest.java
@@ -11,8 +11,12 @@ import co.com.bancolombia.model.inmueble.Inmueble;
 import co.com.bancolombia.model.inmueble.InmuebleConFotos;
 import co.com.bancolombia.model.inmueble.InmuebleStatus;
 import co.com.bancolombia.model.inmueble.PropertyType;
+import co.com.bancolombia.model.exception.ConflictException;
+import co.com.bancolombia.model.exception.NotFoundException;
 import co.com.bancolombia.usecase.inmueble.CrearInmuebleUseCase;
 import co.com.bancolombia.usecase.inmueble.FindAllImobilieByUserUseCase;
+import co.com.bancolombia.usecase.inmueble.PauseInmueblePublicationUseCase;
+import co.com.bancolombia.usecase.inmueble.UpdateInmuebleUseCase;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -47,13 +51,19 @@ class InmuebleHandlerTest {
     @Mock
     private FindAllImobilieByUserUseCase findAllImobilieByUserUseCase;
 
+    @Mock
+    private UpdateInmuebleUseCase updateInmuebleUseCase;
+
+    @Mock
+    private PauseInmueblePublicationUseCase pauseInmueblePublicationUseCase;
+
     private WebTestClient webTestClient;
 
     @BeforeEach
     void setUp() {
         var mapper = new InmuebleApiMapperImpl();
         var validator = Validation.buildDefaultValidatorFactory().getValidator();
-        var handler = new InmuebleHandler(crearInmuebleUseCase, findAllImobilieByUserUseCase, mapper, validator);
+        var handler = new InmuebleHandler(crearInmuebleUseCase, findAllImobilieByUserUseCase, updateInmuebleUseCase, pauseInmueblePublicationUseCase, mapper, validator);
         var routerFunction = new InmuebleRouter().inmuebleRoutes(handler);
 
         var errorHandler = new GlobalErrorHandler();
@@ -254,10 +264,10 @@ class InmuebleHandlerTest {
     }
 
     @Test
-    void getInmueblesByUser_cuandoFaltaHeaderUserId_retorna400() {
+    void getInmueblesByUser_cuandoFaltaHeaderUserId_retorna401() {
         webTestClient.get().uri(URL)
                 .exchange()
-                .expectStatus().isBadRequest()
+                .expectStatus().isUnauthorized()
                 .expectBody()
                 .jsonPath("$.errorCode").isEqualTo("MISSING_USER_IDENTITY");
     }
@@ -301,6 +311,75 @@ class InmuebleHandlerTest {
                 .jsonPath("$.length()").isEqualTo(2)
                 .jsonPath("$[0].id").isEqualTo("test-id")
                 .jsonPath("$[1].id").isEqualTo("test-id-2");
+    }
+
+    // -------------------------------------------------------------------------
+    // PATCH /api/v1/inmuebles/{id}/pause — pauseInmueble
+    // -------------------------------------------------------------------------
+
+    @Test
+    void pauseInmueble_cuandoInmuebleActivo_retorna204() {
+        when(pauseInmueblePublicationUseCase.execute("inmueble-id", "usr_01HX9Z"))
+                .thenReturn(Mono.empty());
+
+        webTestClient.patch().uri(URL + "/inmueble-id/pause")
+                .header(GlobalErrorHandler.USER_ID_HEADER, "usr_01HX9Z")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNoContent();
+    }
+
+    @Test
+    void pauseInmueble_cuandoFaltaHeaderUserId_retorna401() {
+        webTestClient.patch().uri(URL + "/inmueble-id/pause")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isUnauthorized()
+                .expectBody()
+                .jsonPath("$.errorCode").isEqualTo("MISSING_USER_IDENTITY");
+    }
+
+    @Test
+    void pauseInmueble_cuandoInmuebleNoExiste_retorna404() {
+        when(pauseInmueblePublicationUseCase.execute("inmueble-id", "usr_01HX9Z"))
+                .thenReturn(Mono.error(new NotFoundException("NOT_FOUND", "No se encontro el inmueble")));
+
+        webTestClient.patch().uri(URL + "/inmueble-id/pause")
+                .header(GlobalErrorHandler.USER_ID_HEADER, "usr_01HX9Z")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isNotFound()
+                .expectBody()
+                .jsonPath("$.errorCode").isEqualTo("NOT_FOUND");
+    }
+
+    @Test
+    void pauseInmueble_cuandoNoEsPropietario_retorna403() {
+        when(pauseInmueblePublicationUseCase.execute("inmueble-id", "usr_01HX9Z"))
+                .thenReturn(Mono.error(new ForbiddenException("FORBIDDEN", "No tienes permiso para modificar este inmueble")));
+
+        webTestClient.patch().uri(URL + "/inmueble-id/pause")
+                .header(GlobalErrorHandler.USER_ID_HEADER, "usr_01HX9Z")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isForbidden()
+                .expectBody()
+                .jsonPath("$.errorCode").isEqualTo("FORBIDDEN");
+    }
+
+    @Test
+    void pauseInmueble_cuandoEstadoInvalido_retorna409() {
+        when(pauseInmueblePublicationUseCase.execute("inmueble-id", "usr_01HX9Z"))
+                .thenReturn(Mono.error(new ConflictException("INVALID_STATE",
+                        "El inmueble debe estar ACTIVO para pausarse, estado actual: PAUSED")));
+
+        webTestClient.patch().uri(URL + "/inmueble-id/pause")
+                .header(GlobalErrorHandler.USER_ID_HEADER, "usr_01HX9Z")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isEqualTo(409)
+                .expectBody()
+                .jsonPath("$.errorCode").isEqualTo("INVALID_STATE");
     }
 
     // --- helpers ---


### PR DESCRIPTION
Add pause, resume, and renew use cases for inmueble publication lifecycle. Extract publish() and resume() state transitions to the domain model, and introduce Foto.prepareForSave() to encapsulate photo ID assignment.