### PR TITLE
Feature/delete inmueble

### DIFF
--- a/domain/model/src/main/java/co/com/bancolombia/model/inmueble/gateways/InmuebleRepository.java
+++ b/domain/model/src/main/java/co/com/bancolombia/model/inmueble/gateways/InmuebleRepository.java
@@ -9,4 +9,5 @@ public interface InmuebleRepository {
     Mono<Long> countCurrentByUserId(String userId);
     Flux<Inmueble> findAllByUserId(String userId);
     Mono<Inmueble> findById(String id);
+    Mono<Void> deleteInmuebleById(String id);
 }

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/DeleteInmuebleUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/DeleteInmuebleUseCase.java
@@ -1,0 +1,30 @@
+package co.com.bancolombia.usecase.inmueble;
+
+import co.com.bancolombia.model.events.DeleteInmuebleEvent;
+import co.com.bancolombia.model.events.gateways.EventsGateway;
+import co.com.bancolombia.model.foto.gateways.FotoRepository;
+import co.com.bancolombia.model.inmueble.gateways.InmuebleRepository;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class DeleteInmuebleUseCase {
+    private final InmuebleRepository inmuebleRepository;
+    private final FotoRepository fotoRepository;
+    private final EventsGateway eventsGateway;
+
+    public Mono<Void> execute(String inmuebleId, String userId) {
+        return inmuebleRepository.findById(inmuebleId)
+                .map(inmueble -> inmueble.requireOwner(userId))
+                .flatMap(inmueble -> Mono.when(
+                        inmuebleRepository.deleteInmuebleById(inmueble.getId()),
+                        fotoRepository.deleteAllByInmuebleId(inmueble.getId())
+                ))
+                .then(eventsGateway.emit(
+                        DeleteInmuebleEvent.builder()
+                                .inmuebleId(inmuebleId)
+                                .build()
+                        )
+                );
+    }
+}

--- a/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/DeleteInmuebleUseCase.java
+++ b/domain/usecase/src/main/java/co/com/bancolombia/usecase/inmueble/DeleteInmuebleUseCase.java
@@ -19,11 +19,12 @@ public class DeleteInmuebleUseCase {
                 .flatMap(inmueble -> Mono.when(
                         inmuebleRepository.deleteInmuebleById(inmueble.getId()),
                         fotoRepository.deleteAllByInmuebleId(inmueble.getId())
-                ))
-                .then(eventsGateway.emit(
-                        DeleteInmuebleEvent.builder()
-                                .inmuebleId(inmuebleId)
-                                .build()
+                ).then(
+                        eventsGateway.emit(
+                                DeleteInmuebleEvent.builder()
+                                        .inmuebleId(inmuebleId)
+                                        .build()
+                                )
                         )
                 );
     }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/inmueble/InmuebleRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/bancolombia/r2dbc/inmueble/InmuebleRepositoryAdapter.java
@@ -70,4 +70,16 @@ public class InmuebleRepositoryAdapter implements InmuebleRepository {
                         ))
                 );
     }
+
+    @Override
+    public Mono<Void> deleteInmuebleById(String id) {
+        return r2dbcRepository.deleteById(id)
+                .retryWhen(Retry.fixedDelay(2, Duration.ofMillis(150))
+                        .filter(ex -> ex instanceof TransientDataAccessException)
+                        .doBeforeRetry(signal -> log.warn(
+                                "[InmuebleRepository] Reintento #{} en deleteInmuebleById() — causa: {}",
+                                signal.totalRetries() + 1, signal.failure().getMessage()
+                        ))
+                );
+    }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleHandler.java
@@ -31,6 +31,7 @@ public class InmuebleHandler {
     private final PauseInmueblePublicationUseCase pauseInmueblePublicationUseCase;
     private final ResumeInmuebleUseCase resumeInmuebleUseCase;
     private final RenewInmuebleUseCase renewInmuebleUseCase;
+    private final DeleteInmuebleUseCase deleteInmuebleUseCase;
 
     private final InmuebleApiMapper mapper;
     private final Validator validator;
@@ -118,6 +119,16 @@ public class InmuebleHandler {
                     String inmuebleId = request.pathVariable("id");
                     log.info("[RENEW_INMUEBLE] userId={} inmuebleId={} - iniciando renovacion", userId, inmuebleId);
                     return renewInmuebleUseCase.execute(inmuebleId, userId)
+                            .then(ServerResponse.noContent().build());
+                });
+    }
+
+    public Mono<ServerResponse> deleteInmueble (ServerRequest request) {
+        return extractUserId(request)
+                .flatMap(userId -> {
+                    String inmuebleId = request.pathVariable("id");
+                    log.info("[DELETE_INMUEBLE] userId={} inmuebleId={} - iniciando eliminacion", userId, inmuebleId);
+                    return deleteInmuebleUseCase.execute(inmuebleId, userId)
                             .then(ServerResponse.noContent().build());
                 });
     }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleRouter.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/bancolombia/api/inmueble/InmuebleRouter.java
@@ -450,6 +450,83 @@ public class InmuebleRouter {
         ),
         @RouterOperation(
             path = BASE_PATH + "/{id}",
+            method = RequestMethod.DELETE,
+            beanClass = InmuebleHandler.class,
+            beanMethod = "deleteInmueble",
+            operation = @Operation(
+                operationId = "deleteInmueble",
+                summary = "Eliminar un inmueble",
+                description = """
+                    Elimina permanentemente un inmueble junto con todas sus fotos asociadas.
+
+                    **Reglas de negocio:**
+                    - La identidad del propietario se extrae del header `X-User-Id`, propagado por el API Gateway. Si el header está ausente, se retorna `401 Unauthorized`.
+                    - Solo el propietario del inmueble puede eliminarlo. Intentar eliminar un inmueble ajeno retorna `403 Forbidden`.
+                    - Si el inmueble no existe, se retorna `404 Not Found`.
+                    - La eliminación es **permanente e irreversible**: se borran el inmueble y todas sus fotos asociadas.
+                    - Se emite el evento de dominio `co.arriendo.facil.inmueble.delete` para notificar a otros servicios.
+                    """,
+                tags = {"Inmuebles"},
+                parameters = {
+                    @Parameter(
+                        name = "id",
+                        in = ParameterIn.PATH,
+                        description = "Identificador único del inmueble a eliminar",
+                        required = true,
+                        example = "550e8400-e29b-41d4-a716-446655440000",
+                        schema = @Schema(type = "string")
+                    ),
+                    @Parameter(
+                        name = "X-User-Id",
+                        in = ParameterIn.HEADER,
+                        description = "Identificador del usuario propietario, propagado por el API Gateway. Requerido — su ausencia retorna 401.",
+                        required = true,
+                        example = "usr_01HX9Z",
+                        schema = @Schema(type = "string")
+                    )
+                },
+                responses = {
+                    @ApiResponse(
+                        responseCode = "204",
+                        description = "Inmueble y sus fotos eliminados exitosamente"
+                    ),
+                    @ApiResponse(
+                        responseCode = "401",
+                        description = "Header `X-User-Id` ausente o vacío — el API Gateway no propagó la identidad del usuario (errorCode: `MISSING_USER_IDENTITY`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "403",
+                        description = "El usuario no es propietario del inmueble (errorCode: `FORBIDDEN`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "404",
+                        description = "Inmueble no encontrado (errorCode: `NOT_FOUND`)",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    ),
+                    @ApiResponse(
+                        responseCode = "500",
+                        description = "Error interno del servidor",
+                        content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponse.class)
+                        )
+                    )
+                }
+            )
+        ),
+        @RouterOperation(
+            path = BASE_PATH + "/{id}",
             method = RequestMethod.PUT,
             beanClass = InmuebleHandler.class,
             beanMethod = "updateInmueble",
@@ -545,6 +622,7 @@ public class InmuebleRouter {
                 .andRoute(PUT(BASE_PATH + "/{id}").and(accept(MediaType.APPLICATION_JSON)), handler::updateInmueble)
                 .andRoute(PATCH(BASE_PATH + "/{id}/pause").and(accept(MediaType.APPLICATION_JSON)), handler::pauseInmueble)
                 .andRoute(PATCH(BASE_PATH + "/{id}/resume").and(accept(MediaType.APPLICATION_JSON)), handler::resumeInmueble)
-                .andRoute(PATCH(BASE_PATH + "/{id}/renew").and(accept(MediaType.APPLICATION_JSON)), handler::renewInmueble);
+                .andRoute(PATCH(BASE_PATH + "/{id}/renew").and(accept(MediaType.APPLICATION_JSON)), handler::renewInmueble)
+                .andRoute(DELETE(BASE_PATH + "/{id}"), handler::deleteInmueble);
     }
 }


### PR DESCRIPTION
Add permanent deletion of an inmueble and all its associated photos.
The use case enforces ownership via requireOwner() before proceeding,
then deletes the inmueble and its photos in parallel and emits the
domain event co.arriendo.facil.inmueble.delete.

Fix critical bug in InmuebleRouter where the DELETE route was
pointing to handler::updateInmueble instead of handler::deleteInmueble.

Fix minor log tag in InmuebleHandler::deleteInmueble that incorrectly
read [RENEW_INMUEBLE] instead of [DELETE_INMUEBLE].

Add full OpenAPI @RouterOperation for the DELETE endpoint including
business rules, path/header parameters, and 204/401/403/404/500
response documentation.

Closes: https://github.com/Arriendo-facil/ms-immobilie/issues/7